### PR TITLE
Fixes #1: adds missing postgres module on bootup

### DIFF
--- a/images/strapi-alpine/docker-entrypoint.sh
+++ b/images/strapi-alpine/docker-entrypoint.sh
@@ -3,9 +3,9 @@ set -ea
 
 if [ "$*" = "strapi" ]; then
 
-  if [ ! -f "package.json" ]; then
+  DATABASE_CLIENT=${DATABASE_CLIENT:-sqlite}
 
-    DATABASE_CLIENT=${DATABASE_CLIENT:-sqlite}
+  if [ ! -f "package.json" ]; then
 
     EXTRA_ARGS=${EXTRA_ARGS}
 
@@ -209,6 +209,15 @@ EOT
       yarn add "react@^18.0.0" "react-dom@^18.0.0" "react-router-dom@^5.3.4" "styled-components@^5.3.3" --prod || { echo "Adding React and Styled Components failed"; exit 1; }
     else
       npm install react@"^18.0.0" react-dom@"^18.0.0" react-router-dom@"^5.3.4" styled-components@"^5.3.3" --only=prod || { echo "Adding React and Styled Components failed"; exit 1; }
+    fi
+  fi
+
+  if [ "${DATABASE_CLIENT}" -eq "postgres" ] && [ ! grep -q "\"pg\"" package.json ]; then
+    echo "Adding Postgres packages..."
+    if [ -f "yarn.lock" ]; then
+      yarn add "pg@^8.13.0" --prod || { echo "Adding Postgres packages failed"; exit 1; }
+    else
+      npm install pg@"^8.13.0" --only=prod || { echo "Adding Postgres packages failed"; exit 1; }
     fi
   fi
 

--- a/images/strapi-alpine/docker-entrypoint.sh
+++ b/images/strapi-alpine/docker-entrypoint.sh
@@ -212,7 +212,7 @@ EOT
     fi
   fi
 
-  if [ "${DATABASE_CLIENT}" -eq "postgres" ] && [ ! grep -q "\"pg\"" package.json ]; then
+  if [ "${DATABASE_CLIENT}" = "postgres" ] && ! grep -q "\"pg\"" package.json; then
     echo "Adding Postgres packages..."
     if [ -f "yarn.lock" ]; then
       yarn add "pg@^8.13.0" --prod || { echo "Adding Postgres packages failed"; exit 1; }

--- a/images/strapi-debian/docker-entrypoint.sh
+++ b/images/strapi-debian/docker-entrypoint.sh
@@ -3,9 +3,9 @@ set -ea
 
 if [ "$*" = "strapi" ]; then
 
-  if [ ! -f "package.json" ]; then
+  DATABASE_CLIENT=${DATABASE_CLIENT:-sqlite}
 
-    DATABASE_CLIENT=${DATABASE_CLIENT:-sqlite}
+  if [ ! -f "package.json" ]; then
 
     EXTRA_ARGS=${EXTRA_ARGS}
 
@@ -209,6 +209,15 @@ EOT
       yarn add "react@^18.0.0" "react-dom@^18.0.0" "react-router-dom@^5.3.4" "styled-components@^5.3.3" --prod || { echo "Adding React and Styled Components failed"; exit 1; }
     else
       npm install react@"^18.0.0" react-dom@"^18.0.0" react-router-dom@"^5.3.4" styled-components@"^5.3.3" --only=prod || { echo "Adding React and Styled Components failed"; exit 1; }
+    fi
+  fi
+
+  if [ "${DATABASE_CLIENT}" -eq "postgres" ] && [ ! grep -q "\"pg\"" package.json ]; then
+    echo "Adding Postgres packages..."
+    if [ -f "yarn.lock" ]; then
+      yarn add "pg@^8.13.0" --prod || { echo "Adding Postgres packages failed"; exit 1; }
+    else
+      npm install pg@"^8.13.0" --only=prod || { echo "Adding Postgres packages failed"; exit 1; }
     fi
   fi
 

--- a/images/strapi-debian/docker-entrypoint.sh
+++ b/images/strapi-debian/docker-entrypoint.sh
@@ -212,7 +212,7 @@ EOT
     fi
   fi
 
-  if [ "${DATABASE_CLIENT}" -eq "postgres" ] && [ ! grep -q "\"pg\"" package.json ]; then
+  if [ "${DATABASE_CLIENT}" = "postgres" ] && ! grep -q "\"pg\"" package.json; then
     echo "Adding Postgres packages..."
     if [ -f "yarn.lock" ]; then
       yarn add "pg@^8.13.0" --prod || { echo "Adding Postgres packages failed"; exit 1; }


### PR DESCRIPTION
This automatically adds the missing "pg" module required for postgres installations to the `package.json` file.

The module only installs pg@^8.13.0 if the following conditions are met:
- Environment variable `DATABASE_CLIENT` must be set to 'postgres'
- The module '"pg"' is missing from the `package.json` file

Should resolve the following error on new installations:
```
strapi-1  | Starting your app (with develop)...
strapi-1  | 
strapi-1  | > app@0.1.0 develop
strapi-1  | > strapi develop
strapi-1  | 
strapi-1  | - Loading Strapi
strapi-1  | Knex: run
strapi-1  | $ npm install pg --save
strapi-1  | Cannot find module 'pg'
strapi-1  | Require stack:
strapi-1  | - /srv/app/node_modules/knex/lib/dialects/postgres/index.js
strapi-1  | - /srv/app/node_modules/knex/lib/dialects/index.js
strapi-1  | - /srv/app/node_modules/knex/lib/knex-builder/internal/config-resolver.js
strapi-1  | - /srv/app/node_modules/knex/lib/knex-builder/Knex.js
strapi-1  | - /srv/app/node_modules/knex/lib/index.js
strapi-1  | [ERROR]  There seems to be an unexpected error, try again with --debug for more information 
strapi-1  | 
strapi-1  | - /srv/app/node_modules/knex/knex.js
strapi-1  | - /srv/app/node_modules/@strapi/database/dist/index.js
strapi-1  | - /srv/app/node_modules/@strapi/core/dist/Strapi.js
strapi-1  | - /srv/app/node_modules/@strapi/core/dist/index.js
strapi-1  | - /srv/app/node_modules/@strapi/strapi/dist/cli/commands/admin/create-user.js
strapi-1  | - /srv/app/node_modules/@strapi/strapi/dist/cli/commands/index.js
strapi-1  | - /srv/app/node_modules/@strapi/strapi/dist/cli/index.js
strapi-1  | - /srv/app/node_modules/@strapi/strapi/bin/strapi.js
strapi-1  | Error: Cannot find module 'pg'
strapi-1  | Require stack:
strapi-1  | - /srv/app/node_modules/knex/lib/dialects/postgres/index.js
strapi-1  | - /srv/app/node_modules/knex/lib/dialects/index.js
strapi-1  | - /srv/app/node_modules/knex/lib/knex-builder/internal/config-resolver.js
strapi-1  | - /srv/app/node_modules/knex/lib/knex-builder/Knex.js
strapi-1  | - /srv/app/node_modules/knex/lib/index.js
strapi-1  | - /srv/app/node_modules/knex/knex.js
strapi-1  | - /srv/app/node_modules/@strapi/database/dist/index.js
strapi-1  | - /srv/app/node_modules/@strapi/core/dist/Strapi.js
strapi-1  | - /srv/app/node_modules/@strapi/core/dist/index.js
strapi-1  | - /srv/app/node_modules/@strapi/strapi/dist/cli/commands/admin/create-user.js
strapi-1  | - /srv/app/node_modules/@strapi/strapi/dist/cli/commands/index.js
strapi-1  | - /srv/app/node_modules/@strapi/strapi/dist/cli/index.js
strapi-1  | - /srv/app/node_modules/@strapi/strapi/bin/strapi.js
strapi-1  |     at Module._resolveFilename (node:internal/modules/cjs/loader:1140:15)
strapi-1  |     at Module._load (node:internal/modules/cjs/loader:981:27)
strapi-1  |     at Module.require (node:internal/modules/cjs/loader:1231:19)
strapi-1  |     at require (node:internal/modules/helpers:177:18)
strapi-1  |     at Client_PG._driver (/srv/app/node_modules/knex/lib/dialects/postgres/index.js:63:12)
strapi-1  |     at Client_PG.initializeDriver (/srv/app/node_modules/knex/lib/client.js:198:26)
strapi-1  |     at new Client (/srv/app/node_modules/knex/lib/client.js:83:12)
strapi-1  |     at new Client_PG (/srv/app/node_modules/knex/lib/dialects/postgres/index.js:21:5)
strapi-1  |     at Object.knex [as default] (/srv/app/node_modules/knex/lib/knex-builder/Knex.js:16:28)
strapi-1  |     at createConnection (/srv/app/node_modules/@strapi/database/dist/index.js:6877:31)
```