### PR TITLE
Bypass A/B Testing Prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,22 @@ Finally, we have a variable for re-building Strapi. After modifying any of the f
 
 - `BUILD: tobemodified`: A boolean for re-building the Strapi project. Ex. true
 
-> Here is a completed example [compose file](./examples/strapi-postgres/docker-compose.yml) for the available environment variables as well as the configuration for a postgres database. You can find more examples [here](https://github.com/V-Shadbolt/docker-strapi/tree/main/examples).
+### Reverse Proxy Support
+
+When running Strapi behind a reverse proxy (like Caddy, Nginx, or Traefik) in development mode (`NODE_ENV=development`), you might encounter the error:
+
+```
+Blocked request. This host ("api.example.com") is not allowed.
+To allow this host, add "api.example.com" to `server.allowedHosts` in vite.config.js.
+```
+
+This happens because Vite (the development server) blocks requests from hosts that aren't explicitly allowed. To fix this, you can use:
+
+- `ENABLE_VITE_ALLOWED_HOSTS: tobemodified`: A boolean to enable Vite allowed hosts fix. Ex. `true`
+
+When set to `true`, this will automatically create a `vite.config.js` file that allows all hosts, resolving the reverse proxy issue.
+
+> Here is a completed example [compose file](./examples/strapi-postgres/docker-compose.yml) for the available environment variables as well as the configuration for a postgres database. You can find more examples [here](https://github.com/V-Shadbolt/docker-strapi/tree/main/examples), including a [reverse proxy example](./examples/strapi-reverse-proxy/docker-compose.yml).
 
 - The official documentation for Strapi and these files is linked below.
 

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ This happens because Vite (the development server) blocks requests from hosts th
 
 - `ENABLE_VITE_ALLOWED_HOSTS: tobemodified`: A boolean to enable Vite allowed hosts fix. Ex. `true`
 
-When set to `true`, this will automatically create a `vite.config.js` file that allows all hosts, resolving the reverse proxy issue.
+When set to `true`, this will automatically create a `vite.config.js` (for JavaScript projects) or `vite.config.ts` (for TypeScript projects) file that allows all hosts, resolving the reverse proxy issue. The script automatically detects the project type and creates the appropriate configuration file.
 
-> Here is a completed example [compose file](./examples/strapi-postgres/docker-compose.yml) for the available environment variables as well as the configuration for a postgres database. You can find more examples [here](https://github.com/V-Shadbolt/docker-strapi/tree/main/examples), including a [reverse proxy example](./examples/strapi-reverse-proxy/docker-compose.yml).
+> Here is a completed example [compose file](./examples/strapi-postgres/docker-compose.yml) for the available environment variables as well as the configuration for a postgres database. You can find more examples [here](https://github.com/V-Shadbolt/docker-strapi/tree/main/examples).
 
 - The official documentation for Strapi and these files is linked below.
 
@@ -154,7 +154,7 @@ The Docker entrypoint has been modified to add the missing `pg` modules if the S
 
 ### Cannot find module 'mysql'
 
-The Docker entrypoint has been modified to add the missing `pg` modules if the Strapi database is configured to use Postgres starting in `v5.10.2` and `v4.25.20`.
+The Docker entrypoint has been modified to add the missing `mysql` modules if the Strapi database is configured to use MySQL starting in `v5.10.2` and `v4.25.20`.
 
 ---
 

--- a/examples/strapi-postgres/docker-compose.yml
+++ b/examples/strapi-postgres/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       PUBLIC_URL: tobemodified #ex. https://api.example.com
       IMG_ORIGIN: "toBeModified1,toBeModified2" #ex. 'self',data:,blob:,api.example.com,market-assets.strapi.io
       CORS_ORIGIN: "toBeModified1,toBeModified2" #ex. https://mywebsite.example.com,https://api.example.com
+      ENABLE_VITE_ALLOWED_HOSTS: false # Set to true to fix "Blocked request. This host is not allowed" error when using reverse proxy
       DATABASE_CLIENT: postgres
       DATABASE_HOST: strapiDB
       DATABASE_PORT: 5432

--- a/images/strapi-alpine/docker-entrypoint.sh
+++ b/images/strapi-alpine/docker-entrypoint.sh
@@ -130,9 +130,9 @@ EOT
     if [ -f "tsconfig.json" ] || [ -f "package.json" ] && grep -q "\"typescript\"" package.json; then
       echo "Detected TypeScript project, creating vite.config.ts..."
       cat <<-EOT > 'src/admin/vite.config.ts'
-import { mergeConfig } from 'vite';
+import { mergeConfig, type UserConfig } from 'vite';
 
-export default (config: any) => {
+export default (config: UserConfig) => {
   // Important: always return the modified config
   return mergeConfig(config, {
     resolve: {

--- a/images/strapi-alpine/docker-entrypoint.sh
+++ b/images/strapi-alpine/docker-entrypoint.sh
@@ -123,6 +123,28 @@ EOT
     fi
   fi
 
+  if [ "$ENABLE_VITE_ALLOWED_HOSTS" = "true" ] && [ ! -f "src/admin/vite.config.js" ]; then
+    echo "Creating vite.config.js with allowedHosts configuration..."
+    mkdir -p src/admin
+    cat <<-EOT > 'src/admin/vite.config.js'
+const { mergeConfig } = require('vite');
+
+module.exports = (config) => {
+  // Important: always return the modified config
+  return mergeConfig(config, {
+    resolve: {
+      alias: {
+        '@': '/src',
+      },
+    },
+    server: {
+      allowedHosts: true
+    },
+  });
+};
+EOT
+  fi
+
   if [ -f "yarn.lock" ]; then
     current_strapi_version="$(yarn list --pattern strapi --depth=0 | grep @strapi/strapi | cut -d @ -f 3)"
   else

--- a/images/strapi-alpine/docker-entrypoint.sh
+++ b/images/strapi-alpine/docker-entrypoint.sh
@@ -13,7 +13,7 @@ if [ "$*" = "strapi" ]; then
     echo "No project found at /srv/app. Creating a new strapi project ..."
 
     if [ "${STRAPI_VERSION#5}" != "$STRAPI_VERSION" ]; then
-      DOCKER=true npx create-strapi-app@${STRAPI_VERSION} . --no-run \
+      DOCKER=true printf "n\n" | npx create-strapi-app@${STRAPI_VERSION} . --no-run \
         --js \
         --install \
         --no-git-init \

--- a/images/strapi-alpine/docker-entrypoint.sh
+++ b/images/strapi-alpine/docker-entrypoint.sh
@@ -123,12 +123,10 @@ EOT
     fi
   fi
 
-  # Create vite.config.js for existing projects if ENABLE_VITE_ALLOWED_HOSTS is set to true
   if [ "$ENABLE_VITE_ALLOWED_HOSTS" = "true" ] && [ ! -f "src/admin/vite.config.js" ] && [ ! -f "src/admin/vite.config.ts" ]; then
     echo "Creating vite.config with allowedHosts configuration..."
     mkdir -p src/admin
     
-    # Determine if project uses TypeScript
     if [ -f "tsconfig.json" ] || [ -f "package.json" ] && grep -q "\"typescript\"" package.json; then
       echo "Detected TypeScript project, creating vite.config.ts..."
       cat <<-EOT > 'src/admin/vite.config.ts'

--- a/images/strapi-alpine/docker-entrypoint.sh
+++ b/images/strapi-alpine/docker-entrypoint.sh
@@ -123,10 +123,34 @@ EOT
     fi
   fi
 
-  if [ "$ENABLE_VITE_ALLOWED_HOSTS" = "true" ] && [ ! -f "src/admin/vite.config.js" ]; then
-    echo "Creating vite.config.js with allowedHosts configuration..."
+  # Create vite.config.js for existing projects if ENABLE_VITE_ALLOWED_HOSTS is set to true
+  if [ "$ENABLE_VITE_ALLOWED_HOSTS" = "true" ] && [ ! -f "src/admin/vite.config.js" ] && [ ! -f "src/admin/vite.config.ts" ]; then
+    echo "Creating vite.config with allowedHosts configuration..."
     mkdir -p src/admin
-    cat <<-EOT > 'src/admin/vite.config.js'
+    
+    # Determine if project uses TypeScript
+    if [ -f "tsconfig.json" ] || [ -f "package.json" ] && grep -q "\"typescript\"" package.json; then
+      echo "Detected TypeScript project, creating vite.config.ts..."
+      cat <<-EOT > 'src/admin/vite.config.ts'
+import { mergeConfig } from 'vite';
+
+export default (config: any) => {
+  // Important: always return the modified config
+  return mergeConfig(config, {
+    resolve: {
+      alias: {
+        '@': '/src',
+      },
+    },
+    server: {
+      allowedHosts: true
+    },
+  });
+};
+EOT
+    else
+      echo "Detected JavaScript project, creating vite.config.js..."
+      cat <<-EOT > 'src/admin/vite.config.js'
 const { mergeConfig } = require('vite');
 
 module.exports = (config) => {
@@ -143,6 +167,7 @@ module.exports = (config) => {
   });
 };
 EOT
+    fi
   fi
 
   if [ -f "yarn.lock" ]; then

--- a/images/strapi-debian/docker-entrypoint.sh
+++ b/images/strapi-debian/docker-entrypoint.sh
@@ -130,9 +130,9 @@ EOT
     if [ -f "tsconfig.json" ] || [ -f "package.json" ] && grep -q "\"typescript\"" package.json; then
       echo "Detected TypeScript project, creating vite.config.ts..."
       cat <<-EOT > 'src/admin/vite.config.ts'
-import { mergeConfig } from 'vite';
+import { mergeConfig, type UserConfig } from 'vite';
 
-export default (config: any) => {
+export default (config: UserConfig) => {
   // Important: always return the modified config
   return mergeConfig(config, {
     resolve: {

--- a/images/strapi-debian/docker-entrypoint.sh
+++ b/images/strapi-debian/docker-entrypoint.sh
@@ -123,12 +123,10 @@ EOT
     fi
   fi
 
-  # Create vite.config.js for existing projects if ENABLE_VITE_ALLOWED_HOSTS is set to true
   if [ "$ENABLE_VITE_ALLOWED_HOSTS" = "true" ] && [ ! -f "src/admin/vite.config.js" ] && [ ! -f "src/admin/vite.config.ts" ]; then
     echo "Creating vite.config with allowedHosts configuration..."
     mkdir -p src/admin
-    
-    # Determine if project uses TypeScript
+
     if [ -f "tsconfig.json" ] || [ -f "package.json" ] && grep -q "\"typescript\"" package.json; then
       echo "Detected TypeScript project, creating vite.config.ts..."
       cat <<-EOT > 'src/admin/vite.config.ts'

--- a/images/strapi-debian/docker-entrypoint.sh
+++ b/images/strapi-debian/docker-entrypoint.sh
@@ -123,6 +123,28 @@ EOT
     fi
   fi
 
+  if [ "$ENABLE_VITE_ALLOWED_HOSTS" = "true" ] && [ ! -f "src/admin/vite.config.js" ]; then
+    echo "Creating vite.config.js with allowedHosts configuration..."
+    mkdir -p src/admin
+    cat <<-EOT > 'src/admin/vite.config.js'
+const { mergeConfig } = require('vite');
+
+module.exports = (config) => {
+  // Important: always return the modified config
+  return mergeConfig(config, {
+    resolve: {
+      alias: {
+        '@': '/src',
+      },
+    },
+    server: {
+      allowedHosts: true
+    },
+  });
+};
+EOT
+  fi
+
   if [ -f "yarn.lock" ]; then
     current_strapi_version="$(yarn list --pattern strapi --depth=0 | grep @strapi/strapi | cut -d @ -f 3)"
   else

--- a/images/strapi-debian/docker-entrypoint.sh
+++ b/images/strapi-debian/docker-entrypoint.sh
@@ -13,7 +13,7 @@ if [ "$*" = "strapi" ]; then
     echo "No project found at /srv/app. Creating a new Strapi project ..."
 
     if [ "${STRAPI_VERSION#5}" != "$STRAPI_VERSION" ]; then
-      DOCKER=true npx create-strapi-app@${STRAPI_VERSION} . --no-run \
+      DOCKER=true printf "n\n" | npx create-strapi-app@${STRAPI_VERSION} . --no-run \
         --js \
         --install \
         --no-git-init \

--- a/images/strapi-debian/docker-entrypoint.sh
+++ b/images/strapi-debian/docker-entrypoint.sh
@@ -123,10 +123,34 @@ EOT
     fi
   fi
 
-  if [ "$ENABLE_VITE_ALLOWED_HOSTS" = "true" ] && [ ! -f "src/admin/vite.config.js" ]; then
-    echo "Creating vite.config.js with allowedHosts configuration..."
+  # Create vite.config.js for existing projects if ENABLE_VITE_ALLOWED_HOSTS is set to true
+  if [ "$ENABLE_VITE_ALLOWED_HOSTS" = "true" ] && [ ! -f "src/admin/vite.config.js" ] && [ ! -f "src/admin/vite.config.ts" ]; then
+    echo "Creating vite.config with allowedHosts configuration..."
     mkdir -p src/admin
-    cat <<-EOT > 'src/admin/vite.config.js'
+    
+    # Determine if project uses TypeScript
+    if [ -f "tsconfig.json" ] || [ -f "package.json" ] && grep -q "\"typescript\"" package.json; then
+      echo "Detected TypeScript project, creating vite.config.ts..."
+      cat <<-EOT > 'src/admin/vite.config.ts'
+import { mergeConfig } from 'vite';
+
+export default (config: any) => {
+  // Important: always return the modified config
+  return mergeConfig(config, {
+    resolve: {
+      alias: {
+        '@': '/src',
+      },
+    },
+    server: {
+      allowedHosts: true
+    },
+  });
+};
+EOT
+    else
+      echo "Detected JavaScript project, creating vite.config.js..."
+      cat <<-EOT > 'src/admin/vite.config.js'
 const { mergeConfig } = require('vite');
 
 module.exports = (config) => {
@@ -143,6 +167,7 @@ module.exports = (config) => {
   });
 };
 EOT
+    fi
   fi
 
   if [ -f "yarn.lock" ]; then


### PR DESCRIPTION
1. Pipe input of "n" to avoid the A/B Testing prompt. This fakes pressing "N" (no) and avoids blocking the process.

`printf "n\n" | npx create-strapi-app@${STRAPI_VERSION} ...`

2. Added another ENV variable to handle creating vite.config.js and setting allowedHosts to true - enabling all hosts for the strapi admin development server